### PR TITLE
docs(readme): drop 14-day-trial copy; 1.1→1.15; nginx GA, Envoy experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 
 **mod_pagespeed, maintained again.**
 
-Google released its final version of mod_pagespeed in 2020. We-Amp picked it up. [**mod_pagespeed 1.1**](https://modpagespeed.com/1.1/) is the maintained continuation of the original open-source module — a drop-in replacement with the same configuration, the same filters, and the same behavior, plus ongoing security patches, the new [Cyclone Cache](https://modpagespeed.com/1.1/#cyclone), and direct support from the people who know the codebase best.
+Google released its final version of mod_pagespeed in 2020. We-Amp picked it up. [**mod_pagespeed 1.15**](https://modpagespeed.com/1.1/) is the maintained continuation of the original open-source module — a drop-in replacement with the same configuration, the same filters, and the same behavior, plus ongoing security patches, the new [Cyclone Cache](https://modpagespeed.com/1.1/#cyclone), and direct support from the people who know the codebase best.
 
 The project is led by [Otto van der Schaaf](https://github.com/oschaaf), Apache PageSpeed committer and IPMC member, with 360+ pull requests across the upstream codebase.
 
 | | |
 |---|---|
 | **Install (Apache)** | [Quickstart →](https://modpagespeed.com/1.1/docs/getting-started/) |
+| **Install (nginx)** | [Quickstart →](https://modpagespeed.com/1.1/docs/getting-started/) |
 | **Install (IIS)** | [Quickstart →](https://modpagespeed.com/1.1/docs/getting-started/) |
 | **Download packages** | [.deb / .rpm / .msi →](https://modpagespeed.com/download/) |
 | **Upgrade from open-source** | [Migration guide →](https://modpagespeed.com/1.1/docs/upgrading-from-open-source/) |
-| **Pricing** | [$49/server/month — 14-day free trial →](https://modpagespeed.com/pricing/) |
+| **Pricing** | [$49/server/month — free to evaluate, license for production →](https://modpagespeed.com/pricing/) |
 | **Support** | [Email the maintainer →](https://modpagespeed.com/contact/) |
 
-## What's in 1.1
+## What's in 1.15
 
 - **Drop-in replacement.** Same configuration directives, same filters, same `mod_pagespeed.so` semantics. Your existing config keeps working.
 - **Security patches** for known CVEs that accumulated against the archived upstream.
 - **Cyclone Cache** — a new C++23 lock-free shared-memory cache that replaces the legacy file cache. No tuning required; warm-up is automatic.
-- **First-class IIS** — native module for Windows Server 2019 / 2022 with `.msi` installer.
+- **First-class IIS** — native module for Windows Server 2019+ (IIS 10+, 64-bit only) with `.msi` installer.
 - **Modern build** — Bazel-based, pre-built binaries for Debian/Ubuntu (amd64 + arm64), RHEL-family (x86_64 + aarch64), and Windows.
 - **Direct maintainer support** included with every license.
 
@@ -29,11 +30,13 @@ The project is led by [Otto van der Schaaf](https://github.com/oschaaf), Apache 
 | Platform | Status | Packages |
 |---|---|---|
 | **Apache** (amd64 + arm64) | GA | `.deb`, `.rpm`, `.so` |
-| **IIS** (Windows Server 2019/2022) | GA | `.msi` |
-| **nginx** | Coming soon | — |
-| **Envoy** | Coming soon | — |
+| **nginx** (amd64 + arm64) | GA | signed apt/yum dynamic module `nginx-module-pagespeed` (`.deb`, `.rpm`) |
+| **IIS** (Windows Server 2019+) | GA | `.msi` |
+| **Envoy** | Experimental | experimental HTTP filter |
 
-To be notified when nginx and Envoy ship, [sign up on the download page](https://modpagespeed.com/download/).
+The nginx dynamic module ships prebuilt and signed for Debian 11/12/13 and Ubuntu 22.04/24.04 (amd64 + arm64), each pinned to that distribution's stock nginx version. Install via the signed apt/yum repository at [packages.modpagespeed.com](https://packages.modpagespeed.com). The Envoy HTTP filter is experimental — [contact us](https://modpagespeed.com/contact/) for setup guidance.
+
+[Download and run →](https://modpagespeed.com/download/)
 
 ## About this repository
 
@@ -43,10 +46,10 @@ For issues or questions about a running deployment, please [contact the maintain
 
 ## License
 
-mod_pagespeed 1.1 is distributed under the [Business Source License 1.1](https://modpagespeed.com/license/). The first 14 days are a free trial — full features, automatic expiration. See [pricing](https://modpagespeed.com/pricing/) for license details.
+mod_pagespeed 1.15 is distributed under the [Business Source License 1.1](https://modpagespeed.com/license/). Source publication is planned, with no date committed. You can install and run the module unlicensed to evaluate it — it fully optimizes and simply adds an `X-PageSpeed-Warn: unlicensed` response header (plus an admin-console notice and a startup-log warning). A commercial license is required for production use. See [pricing](https://modpagespeed.com/pricing/) for license details.
 
 ## Background
 
-mod_pagespeed was created at Google in 2010 and powered web performance optimization across hundreds of thousands of sites. After Google archived the project, We-Amp B.V. — a Dutch company founded by the former maintainer — continued active development under the mod_pagespeed 1.1 line, alongside a ground-up rewrite, [ModPageSpeed 2.0](https://modpagespeed.com/).
+mod_pagespeed was created at Google in 2010 and powered web performance optimization across hundreds of thousands of sites. After Google archived the project, We-Amp B.V. — a Dutch company founded by the former maintainer — continued active development under the mod_pagespeed 1.15 line, alongside a ground-up rewrite, [ModPageSpeed 2.0](https://modpagespeed.com/).
 
 Learn more about We-Amp's open-source work: [we-amp.com/open-source/](https://we-amp.com/open-source/).


### PR DESCRIPTION
Fact-checked the README against live modpagespeed.com (audit + adversarial verify), matching the same fix shipped to `We-Amp/ngx_pagespeed`:

- **No free trial.** Removed "14-day free trial" / "first 14 days are a free trial — full features, automatic expiration" (×2). Real model: run **unlicensed** to evaluate (fully optimizes + `X-PageSpeed-Warn: unlicensed` header); commercial license required for production.
- **Version 1.1 → 1.15** throughout (heading, body, License, Background). The frozen `/1.1/` URL paths are kept.
- **"Currently shipping" table corrected:** nginx was "Coming soon" → now **GA** (signed apt/yum `nginx-module-pagespeed`, Debian/Ubuntu, amd64+arm64, live since 2026-06-04); Envoy "Coming soon" → **Experimental** (HTTP filter). Added an nginx install row; replaced the stale "notified when nginx and Envoy ship" line.

Verified: no banned/stale phrases remain; `/1.1/` links preserved; package details match the downloads page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)