### PR TITLE
fix(readme): correct PageSpeed provenance (contracted by Google, not "former maintainer")

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ mod_pagespeed 1.15 is distributed under the [Business Source License 1.1](https:
 
 ## Background
 
-mod_pagespeed was created at Google in 2010 and powered web performance optimization across hundreds of thousands of sites. After Google archived the project, We-Amp B.V. — a Dutch company that built ngx_pagespeed and supported mod_pagespeed under contract to Google — continued active development under the mod_pagespeed 1.15 line, alongside a ground-up rewrite, [ModPageSpeed 2.0](https://modpagespeed.com/).
+mod_pagespeed was created at Google in 2010 and powered web performance optimization across hundreds of thousands of sites. After Google archived the project, We-Amp B.V. — a Dutch company that helped build and maintain ngx_pagespeed and mod_pagespeed — continued active development in the Apache PageSpeed incubator project and after that under the mod_pagespeed 1.15 line, alongside a ground-up rewrite, [ModPageSpeed 2.0](https://modpagespeed.com/).
 
 Learn more about We-Amp's open-source work: [we-amp.com/open-source/](https://we-amp.com/open-source/).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ mod_pagespeed 1.15 is distributed under the [Business Source License 1.1](https:
 
 ## Background
 
-mod_pagespeed was created at Google in 2010 and powered web performance optimization across hundreds of thousands of sites. After Google archived the project, We-Amp B.V. — a Dutch company founded by the former maintainer — continued active development under the mod_pagespeed 1.15 line, alongside a ground-up rewrite, [ModPageSpeed 2.0](https://modpagespeed.com/).
+mod_pagespeed was created at Google in 2010 and powered web performance optimization across hundreds of thousands of sites. After Google archived the project, We-Amp B.V. — a Dutch company that built ngx_pagespeed and supported mod_pagespeed under contract to Google — continued active development under the mod_pagespeed 1.15 line, alongside a ground-up rewrite, [ModPageSpeed 2.0](https://modpagespeed.com/).
 
 Learn more about We-Amp's open-source work: [we-amp.com/open-source/](https://we-amp.com/open-source/).


### PR DESCRIPTION
Corrects the one line in the README that frames We-Amp / its founder as the **"former mod_pagespeed maintainer"** of Google's project.

We-Amp was **contracted by Google** to build ngx_pagespeed and support mod_pagespeed, and helped drive the Apache PageSpeed incubation — never a Google employee or maintainer of Google's project. Otto van der Schaaf stays credited as project lead with his **accurate** Apache PageSpeed committer / IPMC member credit; only the false framing is removed. Surgical single-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)